### PR TITLE
4.1.1

### DIFF
--- a/docs/shortcodes/sc-db-value-by-id.md
+++ b/docs/shortcodes/sc-db-value-by-id.md
@@ -6,7 +6,7 @@ Fetch a value from the given MySQL table. Specify which column the value should 
 
 For example, the following shortcode usage, will run the SQL specified below.
 
-`[sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d"]`
+`[sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d"]`
 
 *Pseudo MySQL:*
 
@@ -22,11 +22,11 @@ The shortcode supports the following arguments:
 
 | Argument          | Description                                                                              | Options                                         | Example |
 |-------------------|------------------------------------------------------------------------------------------|-------------------------------------------------|--|
-| table             | MySQL table to search                                                                    | text                                            | [sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d"]
-| cache             | If enabled, cache the results of the SQL query for the number of seconds specified by    | True (default) or False                         | [sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d" cache=false]
-| cache-duration    | Number of seconds the data should be cached for (before hitting the database again)      | Number, default 3600 seconds (1 hour)           | [sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d" cache=true cache-duration=60]
-| column            | MySQL table column to return                                                             | text                                            | [sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d"]
-| column-to-search  | MySQL column to use in Where clause                                                      | text                                            | [sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d"]
-| key               | Value to compare against colum-to-search                                                 | text                                            | [sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d"]
-| key-format        | To stop SQL injection, a format (either numeric or string) must be specified for the key | Either "%d" (for a number) or "%s" for a string | [sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d"]
-| message-not-found | Message to display if no value can be found for the given key.                           | Either blank or text                            | [sv slug="sc-db-value-by-id" table="users" column="user_login" column-to-search="id" key="3" key-format="%d" message-not-found="Could not find user"]
+| table             | MySQL table to search                                                                    | text                                            | [sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d"]
+| cache             | If enabled, cache the results of the SQL query for the number of seconds specified by    | True (default) or False                         | [sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d" cache=false]
+| cache-duration    | Number of seconds the data should be cached for (before hitting the database again)      | Number, default 3600 seconds (1 hour)           | [sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d" cache=true cache-duration=60]
+| column            | MySQL table column to return                                                             | text                                            | [sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d"]
+| column-to-search  | MySQL column to use in Where clause                                                      | text                                            | [sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d"]
+| key               | Value to compare against colum-to-search                                                 | text                                            | [sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d"]
+| key-format        | To stop SQL injection, a format (either numeric or string) must be specified for the key | Either "%d" (for a number) or "%s" for a string | [sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d"]
+| message-not-found | Message to display if no value can be found for the given key.                           | Either blank or text                            | [sv slug="sc-db-value-by-id" table="wp_users" column="user_login" column-to-search="id" key="3" key-format="%d" message-not-found="Could not find user"]

--- a/includes/shortcode.presets.premium.php
+++ b/includes/shortcode.presets.premium.php
@@ -429,7 +429,7 @@ class SV_SC_DB_VALUE_BY_ID extends SV_Preset {
 
 		$sql = sprintf( 'Select %s from %s where %s = %s',
 								$args['column'],
-								$wpdb->prefix . $args['table'],
+								$args['table'],
 								$args['column-to-search'],
 								$args['key-format']
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/yeken
 Tags: shortcode, variable, php, text, html, parameter, javascript, embed, reuse
 Requires at least: 5.7
 Tested up to: 6.4.1
-Stable tag: 4.1
+Stable tag: 4.1.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -146,6 +146,10 @@ Login into Wordpress Admin Panel and goto Settings > Snippet Shortcodes
 4.1 -[sv slug="sc-db-value-by-id"], new Premium shortcode for fetching a value from a MySQL table.
 
 == Changelog ==
+
+= 4.1.1 =
+
+* Improvement: Dropped the database table prefix from the shortcode [sv slug="sc-db-value-by-id"] e.g. instead of specifying "users" table, it would now be "wp_users" (i.e. if a WP table, specify the prefix)
 
 = 4.1 =
 

--- a/shortcode-variables.php
+++ b/shortcode-variables.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die("Jog on!");
 /**
  * Plugin Name: Snippet Shortcodes
  * Description: Create your own shortcodes and assign text / variables to it or use our premade ones. You can then embed these shortcodes throughout your entire site and only have to change the value in one place.
- * Version: 4.1
+ * Version: 4.1.1
  * Requires at least:   5.7
  * Tested up to: 		6.4.1
  * Requires PHP:        7.4
@@ -34,7 +34,7 @@ defined('ABSPATH') or die("Jog on!");
 
 define( 'SH_CD_ABSPATH', plugin_dir_path( __FILE__ ) );
 
-define( 'SH_CD_PLUGIN_VERSION', '4.1' );
+define( 'SH_CD_PLUGIN_VERSION', '4.1.1' );
 define( 'SH_CD_PLUGIN_NAME', 'Snippet Shortcodes' );
 define( 'SH_CD_TABLE', 'SH_CD_SHORTCODES' );
 define( 'SH_CD_TABLE_MULTISITE', 'SH_CD_SHORTCODES_MULTISITE' );


### PR DESCRIPTION
* Improvement: Dropped the database table prefix from the shortcode [sv slug="sc-db-value-by-id"] e.g. instead of specifying "users" table, it would now be "wp_users" (i.e. if a WP table, specify the prefix)